### PR TITLE
Questions about hard-set of jenkins version.

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -17,7 +17,7 @@
 # Apache 2.0
 #
 node.set['jenkins']['master']['install_method'] = 'war'
-node.set['jenkins']['master']['version'] = '1.555'
+#node.set['jenkins']['master']['version'] = '1.555'
 node.set['jenkins']['executor']['timeout'] = 300
 
 mirror = node['jenkins']['master']['mirror']


### PR DESCRIPTION
Hi, there!

When the attached diff is in place, I can override the version and install jenkins 2.x (I was using the beta, with a specified path to the 2.0rc directory on the mirror....).

If I let the node.set happen here, I wind up with jenkins 1.555 - which isn't what I wanted.  

I'd suggest using  node.default or something here, rather than the node.set/node.normal.... but I'm still not sure it will cure my problem.  I suppose it doesn't matter _that_ much -- 2.0 appears to have released today, and I imagine it will start to become the normal in the community shortly.

Just wanted to discuss -- I'm not completely sure what the right thing to do here is.  

best,

--e
